### PR TITLE
Migración actualizada para la tabla "respuestas"

### DIFF
--- a/teuler/database/migrations/2024_10_14_230040_respuestas.php
+++ b/teuler/database/migrations/2024_10_14_230040_respuestas.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('respuestas', function (Blueprint $table) {
             $table->id();
             $table->foreignId('id_usuario')->constrained('usuarios');
-            $table->foreignId('id_reactivo')->constrained('modulos_tematicos');  //revisar
+            $table->string('id_reactivo', 24);  //el ID del reactivo se jala desde MongoDB
             $table->foreignId('id_modulo')->constrained('modulos_tematicos');
             $table->string('respuesta_alumno', 1);
             $table->boolean('es_correcto');

--- a/teuler/resources/views/cursos/algebra/despejes/tema2_despeje_incognitas.blade.php
+++ b/teuler/resources/views/cursos/algebra/despejes/tema2_despeje_incognitas.blade.php
@@ -67,4 +67,9 @@
 </div>
 <!-- FIN DIV EXPLICACIÓN -->
 
+<div class="container flex justify-end pr-5 pb-5">
+
+<a href="/despeje_incognitas_ejercicios" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar bloque de ejercicios</a>
+
+</div>
 @endsection


### PR DESCRIPTION
Se modificó el tipo de dato del campo "id_reactivo" a tipo string, ya que MongoDB genera IDs alfanuméricos de 24 caracteres y ese campo recibirá los IDs de las preguntas almacenadas en MongoDB