### PR TITLE
Implementación de bloques de preguntas a cada módulo

### DIFF
--- a/teuler/app/Http/Controllers/ModuloTematicoController.php
+++ b/teuler/app/Http/Controllers/ModuloTematicoController.php
@@ -70,7 +70,7 @@ class ModuloTematicoController extends Controller
         }
     
         // Procesar respuesta del alumno
-        $respuestaAlumno = trim((string) $request->input('respuesta')); // Convertir a string y limpiar espacios
+        $respuestaAlumno = trim((string) $request->input('respuesta'));
         $esCorrecto = false;
     
         // Comparar según el tipo de pregunta
@@ -97,17 +97,21 @@ class ModuloTematicoController extends Controller
         $progresoModulo->progreso += 10;
         $progresoModulo->save();
     
-        // Verificar si se completó el bloque
+        // Verificar si se completó el bloque y establecer redirección dinámica
         $redirectUrl = null;
         if ($progresoModulo->progreso >= 100) {
-            $redirectUrl = route('preguntas_despejes'); 
+            $redirectUrl = match ($modulo->nombre) {
+                'Despejes y Ecuaciones Lineales' => route('preguntas_despejes'),
+                'Expresiones Algebraicas' => route('preguntas_simplificacion'),
+                default => route('home'), // Ruta genérica si no coincide
+            };
         }
     
         return response()->json([
             'success' => true,
             'progreso' => $progresoModulo->progreso,
             'es_correcto' => $esCorrecto,
-            'redirect' => $redirectUrl, 
+            'redirect' => $redirectUrl,
         ]);
     }
     

--- a/teuler/resources/views/cursos/algebra/despejes/tema2_despeje_incognitas.blade.php
+++ b/teuler/resources/views/cursos/algebra/despejes/tema2_despeje_incognitas.blade.php
@@ -69,7 +69,7 @@
 
 <div class="container flex justify-end pr-5 pb-5">
 
-<a href="/modulo/1/preguntas" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar bloque de ejercicios</a>
+<a href="/modulo/4/preguntas" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar bloque de ejercicios</a>
 
 </div>
 @endsection

--- a/teuler/resources/views/cursos/algebra/expresiones/index_expresiones.blade.php
+++ b/teuler/resources/views/cursos/algebra/expresiones/index_expresiones.blade.php
@@ -1,19 +1,78 @@
 @extends('layouts.template_teuler')
-@section('titulo','Expresiones algebraicas')
+@section('titulo','Expresiones Algebraicas')
 @section('contenido')
 
 <main class="flex-grow mb-10 pb-10 pt-10">
-        <section class="bg-white py-20">
-            <div class="container mx-auto px-4 text-center">
-                <h1 class="text-4xl font-bold text-gray-800 mb-6">¡Bienvenido a expresiones algebraicas!</h1>
-                <p class="text-lg text-gray-600 mb-8">
-                En este módulo, aprenderás a dominar los conceptos básicos del lenguaje matemático, que te permitirán resolver problemas de manera más rápida y eficiente. Desde entender cómo simplificar ecuaciones hasta manipular términos algebraicos, este curso te guiará paso a paso. 
-                </p>
-                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Comenzar ahora</a>
-            </div>
-        </section>
+    <section class="bg-white py-20 pb-12">
+        <div class="container mx-auto px-4 text-center">
+            <h1 class="text-4xl font-bold text-gray-800 mb-6">¡Bienvenido a Expresiones Algebraicas!</h1>
+            <p class="text-lg text-gray-600 mb-8">
+                En este módulo, aprenderás a dominar los conceptos básicos del lenguaje matemático, que te permitirán resolver problemas de manera más rápida y eficiente. Desde entender cómo simplificar ecuaciones hasta manipular términos algebraicos, este curso te guiará paso a paso.
+            </p>
+        </div>
+    </section>
 
-     
-    </main>
-    
+    <div class="container mx-auto px-4 py-12">
+        <h1 class="text-4xl font-bold text-gray-800 text-center mb-10">Temario</h1> 
+
+        <div class="space-y-8">
+            <!-- Sección 1 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">1. Introducción a las Expresiones Algebraicas</h2>
+                <p class="text-gray-600">Explorarás los elementos básicos de una expresión algebraica, incluyendo variables, constantes y términos. Comprenderás cómo identificar y organizar las partes fundamentales de una expresión.</p>
+                <br>
+                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+
+            <!-- Sección 2 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">2. Simplificación de Expresiones Algebraicas</h2>
+                <p class="text-gray-600">Aprenderás a combinar términos semejantes y a aplicar propiedades básicas como la conmutativa y asociativa para simplificar expresiones algebraicas de manera eficiente.</p>
+                <br>
+                <a href="/simplificacion_expresiones" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+
+            <!-- Sección 3 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">3. Propiedad Distributiva</h2>
+                <p class="text-gray-600">Descubrirás cómo expandir y simplificar expresiones usando la propiedad distributiva. Practicarás cómo manejar paréntesis en expresiones algebraicas de diferentes niveles de complejidad.</p>
+                <br>
+                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+
+            <!-- Sección 4 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">4. Factores y Factorización</h2>
+                <p class="text-gray-600">Dominarás técnicas de factorización, como el factor común y el agrupamiento. Esto te permitirá transformar expresiones complejas en formas más manejables.</p>
+                <br>
+                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+
+            <!-- Sección 5 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">5. Operaciones con Polinomios</h2>
+                <p class="text-gray-600">Aprenderás a sumar, restar, multiplicar y dividir polinomios, desarrollando habilidades para trabajar con expresiones algebraicas más complejas.</p>
+                <br>
+                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+
+            <!-- Sección 6 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">6. Expresiones Racionales</h2>
+                <p class="text-gray-600">Explorarás cómo trabajar con expresiones que involucran fracciones algebraicas, aprendiendo a simplificarlas y realizar operaciones con ellas.</p>
+                <br>
+                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+
+            <!-- Sección 7 -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <h2 class="text-2xl font-semibold text-blue-700 mb-4">7. Aplicaciones de Expresiones Algebraicas</h2>
+                <p class="text-gray-600">Aplicarás los conceptos aprendidos para resolver problemas reales, modelando situaciones prácticas mediante el uso de expresiones algebraicas.</p>
+                <br>
+                <a href="#" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar lección</a>
+            </div>
+        </div>
+    </div>
+</main>
+
 @endsection

--- a/teuler/resources/views/cursos/algebra/expresiones/tema2_simplificacion.blade.php
+++ b/teuler/resources/views/cursos/algebra/expresiones/tema2_simplificacion.blade.php
@@ -1,0 +1,85 @@
+@extends('layouts.template_teuler')
+@section('titulo','Simplificación de expresiones algebraicas')
+@section('contenido')
+
+<div class="container mx-auto mt-10 pb-10 px-4 flex justify-center">
+    <h1 class="mt 10 flex items-center text-gray-900 font-sans font-bold text-2xl">Simplificación de expresiones algebraicas</h1>
+</div>
+
+<!-- DIV EXPLICACIÓN -->
+<div class="container mx-auto mb-10 pb-10 pl-10 pr-10">
+  <p class="text-lg leading-relaxed text-gray-800">
+    <span class="font-semibold">La simplificación de expresiones algebraicas</span> es el proceso de reducir una expresión matemática a su forma más sencilla, combinando términos semejantes, eliminando paréntesis y realizando operaciones básicas. Esto permite resolver problemas de manera más rápida y eficiente, manteniendo la claridad en los cálculos.
+  </p>
+
+  <h2 class="mt-6 text-xl font-semibold text-gray-900 flex justify-center">Ejemplo básico:</h2>
+  <p class="leading-relaxed text-gray-800 flex justify-center">
+    Simplifiquemos la expresión:
+    <pre class="bg-gray-100 p-3 rounded-md mt-2 flex justify-center">2x + 3x - 5</pre>
+  </p>
+  
+  <p class="mt-4 leading-relaxed text-gray-800 flex justify-center">
+    Para simplificar, sigue estos pasos:
+  </p>
+
+  <ol class="list-decimal list-inside mt-4 text-gray-800 space-y-2 flex justify-center">
+    <li>
+      <span class="font-semibold">Identifica términos semejantes:</span>
+      <p class="mt-2">
+        En este caso, los términos semejantes son <span class="font-semibold">2x</span> y <span class="font-semibold">3x</span>, ya que ambos contienen la misma variable <span class="font-semibold">x</span>.
+      </p>
+    </li>
+
+    <li>
+      <span class="font-semibold">Suma o resta los coeficientes:</span>
+      <p class="mt-2">
+        Sumamos los coeficientes de <span class="font-semibold">2x</span> y <span class="font-semibold">3x</span>:
+      </p>
+      <pre class="bg-gray-100 p-3 rounded-md mt-2 flex justify-center">(2 + 3)x = 5x</pre>
+    </li>
+
+    <li>
+      <span class="font-semibold">Incluye los términos restantes:</span>
+      <p class="mt-2">
+        El resultado final es:
+      </p>
+      <pre class="bg-gray-100 p-3 rounded-md mt-2 flex justify-center">5x - 5</pre>
+    </li>
+  </ol>
+
+  <h2 class="mt-6 text-xl font-semibold text-gray-900 flex justify-center">Ejemplo con paréntesis:</h2>
+  <p class="leading-relaxed text-gray-800 flex justify-center">
+    Simplifiquemos:
+    <pre class="bg-gray-100 p-3 rounded-md mt-2 flex justify-center">3(2x + 4) - 5x</pre>
+  </p>
+
+  <ol class="list-decimal list-inside mt-4 text-gray-800 space-y-2 flex justify-center">
+    <li>
+      <span class="font-semibold">Aplica la propiedad distributiva:</span>
+      <p class="mt-2">
+        Multiplica <span class="font-semibold">3</span> por cada término dentro del paréntesis:
+      </p>
+      <pre class="bg-gray-100 p-3 rounded-md mt-2 flex justify-center">6x + 12 - 5x</pre>
+    </li>
+
+    <li>
+      <span class="font-semibold">Combina términos semejantes:</span>
+      <p class="mt-2">
+        Simplifica <span class="font-semibold">6x - 5x</span>:
+      </p>
+      <pre class="bg-gray-100 p-3 rounded-md mt-2 flex justify-center">x + 12</pre>
+    </li>
+  </ol>
+
+  <p class="mt-6 text-gray-800 flex justify-center">
+    Simplificar expresiones te ayuda a trabajar de manera más ordenada y a resolver problemas matemáticos con mayor claridad.
+  </p>
+</div>
+<!-- FIN DIV EXPLICACIÓN -->
+
+<div class="container flex justify-end pr-5 pb-5">
+
+<a href="/modulo/1/preguntas" class="bg-blue-700 text-white py-3 px-6 rounded-lg shadow hover:bg-blue-900 transition duration-300">Empezar bloque de ejercicios</a>
+
+</div>
+@endsection

--- a/teuler/resources/views/preguntas.blade.php
+++ b/teuler/resources/views/preguntas.blade.php
@@ -77,54 +77,51 @@
         method: "POST",
         headers: {
             "X-CSRF-TOKEN": document.querySelector('input[name="_token"]').value,
-            "Content-Type": "application/json",
+            "Content-Type": "application/json"
         },
         body: JSON.stringify({
             pregunta_id: preguntaId,
             modulo_id: {{ $modulo_id }},
-            respuesta: respuesta,
-        }),
+            respuesta: respuesta
+        })
     })
-        .then(response => response.json())
-        .then(data => {
-            console.log("Respuesta del servidor:", data);
+    .then(response => response.json())
+    .then(data => {
+        console.log("Respuesta del servidor:", data);
 
-            if (data.success) {
-                // Retroalimentación visual
-                const currentPregunta = document.getElementById(`pregunta-${index}`);
-                if (data.es_correcto) {
-                    currentPregunta.style.border = "2px solid green";
-                } else {
-                    currentPregunta.style.border = "2px solid red";
-                }
+        if (data.success) {
+            const currentPregunta = document.getElementById(`pregunta-${index}`);
+            if (data.es_correcto) {
+                currentPregunta.style.border = "2px solid green";
+            } else {
+                currentPregunta.style.border = "2px solid red";
+            }
 
-                // Actualizar barra de progreso
-                progreso += 1;
-                const progressBar = document.getElementById("progress-bar");
-                if (progressBar) {
-                    const porcentaje = (progreso / totalPreguntas) * 100;
-                    progressBar.style.width = `${porcentaje}%`;
-                    progressBar.textContent = `${Math.round(porcentaje)}%`; // Opcional: mostrar porcentaje en la barra
-                } else {
-                    console.error("Elemento 'progress-bar' no encontrado.");
-                }
+            progreso += 1;
+            const progressBar = document.getElementById("progress-bar");
+            if (progressBar) {
+                const porcentaje = (progreso / totalPreguntas) * 100;
+                progressBar.style.width = `${porcentaje}%`;
+                progressBar.textContent = `${Math.round(porcentaje)}%`;
+            }
 
-                // Comprobar si se debe redirigir al usuario
+            if (progreso >= totalPreguntas) {
                 if (data.redirect) {
-                    alert('¡Bloque completado! Redirigiendo a la página de finalización.');
-                    window.location.href = data.redirect;
-                } else if (progreso < totalPreguntas) {
-                    // Avanzar a la siguiente pregunta
-                    mostrarSiguientePregunta(index + 1);
+                    window.location.href = data.redirect; // Redirigir a la URL especificada
+                } else {
+                    alert('¡Bloque completado!');
                 }
             } else {
-                alert(data.message || "Hubo un error al guardar la respuesta.");
+                mostrarSiguientePregunta(index + 1);
             }
-        })
-        .catch(error => {
-            console.error("Error:", error);
-            alert("Error en la conexión. Inténtalo de nuevo.");
-        });
+        } else {
+            alert(data.message || 'Hubo un error al guardar la respuesta.');
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+        alert('Error en la conexión. Inténtalo de nuevo.');
+    });
 }
 
 

--- a/teuler/routes/web.php
+++ b/teuler/routes/web.php
@@ -88,6 +88,10 @@ Route::get('/despeje_incognitas_ejercicios', function () {
     return view('cursos.algebra.despejes.ejercicios_despejes_incognitas');
 });
 
+Route::get('/simplificacion_expresiones', function () {
+    return view('cursos.algebra.expresiones.tema2_simplificacion');
+})->name('preguntas_simplificacion');
+
 /* Route::get('/perfil', function () {
     return view('perfil_usuario');
 }); */


### PR DESCRIPTION
Anteriormente se establa probando esta función en un sólo módulo. Actualmente, tanto el módulo temático de despejes, como el de expresiones algebraicas ya tienen la funcionalidad.

Hace falta actualizar los registros en mongo en el tema de despejes para quitar el "<br>".

Al finalizar un bloque de preguntas, se guardan las respuestas, se actualiza la barra de estado y se registra el avance en la tabla "progreso_modulo" y se redirige al usuario a la vista de la explicación del tema.

Hace falta modificar el título del navegador para que sea dinámico (@section('titulo', '...')).